### PR TITLE
fix: set onSemanticsUpdate to empty function

### DIFF
--- a/lib/src/bindings/pipeline_owner.dart
+++ b/lib/src/bindings/pipeline_owner.dart
@@ -5,6 +5,13 @@ class SimulatorPipelineOwner extends PipelineOwner {
   VoidCallback? onAfterFlushCompositingBits;
   VoidCallback? onAfterFlushPaint;
 
+  SimulatorPipelineOwner()
+      : super(
+          // Prevents crash on Linux from non-null assertion
+          // (https://github.com/kekland/simulator/issues/1)
+          onSemanticsUpdate: (_) {},
+        );
+
   @override
   void flushCompositingBits() {
     super.flushCompositingBits();


### PR DESCRIPTION
Fixes #1 

Tested working on Fedora 40:
![image](https://github.com/kekland/simulator/assets/21128619/fb861741-c443-466b-98f1-dccda90ad8e3)
